### PR TITLE
Use install paths in installed cmake files

### DIFF
--- a/double-conversionConfig.cmake.in
+++ b/double-conversionConfig.cmake.in
@@ -8,10 +8,9 @@ get_filename_component(double-conversion_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" 
 if(EXISTS "${double-conversion_CMAKE_DIR}/CMakeCache.txt")
   include("${double-conversion_CMAKE_DIR}/double-conversionBuildTreeSettings.cmake")
 else()
-  set(double-conversion_INCLUDE_DIRS
-    "${double-conversion_CMAKE_DIR}/@CONF_REL_INCLUDE_DIR@/include/double-conversion")
+  set(double-conversion_INCLUDE_DIRS "@INCLUDE_INSTALL_DIR@/double-conversion")
 endif()
 
-include("${double-conversion_CMAKE_DIR}/double-conversionLibraryDepends.cmake")
+include("@LIB_INSTALL_DIR@/cmake/double-conversion/double-conversionLibraryDepends.cmake")
 
 set(double-conversion_LIBRARIES double-conversion)


### PR DESCRIPTION
Fedora's UsrMove causes issues with get_fileame_components returning odd paths.

Since we know the location of the file, just use it.  This also assumes changing CMake to cmake in the cmake file install location.  You might want to use another variable here instead.